### PR TITLE
Feat/aircraft manufacturer backend

### DIFF
--- a/backend/src/aircrafts/aircrafts.service.ts
+++ b/backend/src/aircrafts/aircrafts.service.ts
@@ -35,19 +35,16 @@ export class AircraftsService {
         `Aircraft ${createAircraftDto.registry} already exists`,
       );
     }
-    const manufacturer = await this.manufacturersService.findOneById(
-      createAircraftDto.manufacturer,
+    const manufacturer = await this.manufacturersService.findById(
+      createAircraftDto.manufacturer.id,
     );
 
     if (!manufacturer) {
       throw new NotFoundException('Manufacturer not found');
     }
 
-    if (
-      createAircraftDto.airline &&
-      !this.airlinesService.findOneById(createAircraftDto.airline)
-    ) {
-      throw new NotFoundException('Airline not found');
+    if (createAircraftDto.airline) {
+      await this.airlinesService.findById(createAircraftDto.airline.id);
     }
 
     const aircraft = this.aircraftRepository.create(createAircraftDto);

--- a/backend/src/aircrafts/dto/create-aircraft.dto.ts
+++ b/backend/src/aircrafts/dto/create-aircraft.dto.ts
@@ -37,7 +37,7 @@ export class CreateAircraftDto {
   @Min(1)
   passengerCapacity: number;
 
-  @IsEnum(Status)
+  @IsString()
   status: Status;
 
   @IsNotEmpty()

--- a/backend/src/aircrafts/entities/aircraft.entity.ts
+++ b/backend/src/aircrafts/entities/aircraft.entity.ts
@@ -14,7 +14,7 @@ import {
 // Internal Imports
 import { Airline } from '../../airlines/entities/airline.entity';
 import { Manufacturer } from '../../manufacturers/entities/manufacturer.entity';
-import { Status } from '../../types/AircraftsTypes';
+import type { Status } from '../../types/AircraftsTypes';
 
 @Entity()
 export class Aircraft {
@@ -30,7 +30,7 @@ export class Aircraft {
   @Column({ type: 'int' })
   passengerCapacity: number;
 
-  @Column({ type: 'enum', enum: Status })
+  @Column({ type: 'enum' })
   status: Status;
 
   @Column({ type: 'date' })

--- a/backend/src/manufacturers/entities/manufacturer.entity.ts
+++ b/backend/src/manufacturers/entities/manufacturer.entity.ts
@@ -38,7 +38,6 @@ export class Manufacturer {
   @OneToMany(() => Aircraft, (aircraft) => aircraft.manufacturer)
   @JoinColumn({
     referencedColumnName: 'id',
-    nullable: true,
   })
   aircrafts: Aircraft[];
 }

--- a/backend/src/manufacturers/manufacturers.controller.ts
+++ b/backend/src/manufacturers/manufacturers.controller.ts
@@ -34,7 +34,7 @@ export class ManufacturersController {
 
   @Get(':id')
   async findOne(@Param('id') id: string): Promise<Manufacturer> {
-    return await this.manufacturersService.findOneById(id);
+    return await this.manufacturersService.findById(id);
   }
 
   @Patch(':id')

--- a/backend/src/manufacturers/manufacturers.service.ts
+++ b/backend/src/manufacturers/manufacturers.service.ts
@@ -41,7 +41,7 @@ export class ManufacturersService {
     return await this.manufacturerRepository.find();
   }
 
-  async findOneById(id: string): Promise<Manufacturer> {
+  async findById(id: string): Promise<Manufacturer> {
     const manufacturer = await this.manufacturerRepository.findOneBy({ id });
     if (!manufacturer) {
       throw new NotFoundException(`Manufacturer ${id} not found`);
@@ -54,7 +54,7 @@ export class ManufacturersService {
     id: string,
     updateManufacturerDto: UpdateManufacturerDto,
   ): Promise<UpdateResult> {
-    const manufacturer = await this.findOneById(id);
+    const manufacturer = await this.findById(id);
     if (!manufacturer) {
       throw new NotFoundException(`Manufacturer ${id} not found`);
     }
@@ -63,7 +63,7 @@ export class ManufacturersService {
   }
 
   async remove(id: string): Promise<DeleteResult> {
-    const manufacturer = await this.findOneById(id);
+    const manufacturer = await this.findById(id);
     if (!manufacturer) {
       throw new NotFoundException(`Manufacturer ${id} not found`);
     }


### PR DESCRIPTION
This pull request introduces several refactorings and minor corrections across the aircraft and manufacturer modules, primarily to standardize method naming, improve type usage, and correct validation and entity definitions.

**Refactoring and Standardization**

* Renamed the `findOneById` method to `findById` in `ManufacturersService` and updated all usages throughout the codebase for consistency. [[1]](diffhunk://#diff-a61a3695c8e57521bc54889864700f44b12a8d51f5502250c070c59a85ec1b57L44-R44) [[2]](diffhunk://#diff-dab9d51933473bb3f89a9d1548fc4f3c2fdc830d75095cb226910307509d17f1L37-R37) [[3]](diffhunk://#diff-a61a3695c8e57521bc54889864700f44b12a8d51f5502250c070c59a85ec1b57L57-R57) [[4]](diffhunk://#diff-a61a3695c8e57521bc54889864700f44b12a8d51f5502250c070c59a85ec1b57L66-R66) [[5]](diffhunk://#diff-93221c02d8c2dbbc65316d4ababa55923149e8fe4087d97349c9599d42e83aa7L38-R47)

**Validation and Type Improvements**

* Changed the validation for the `status` property in `CreateAircraftDto` from `@IsEnum(Status)` to `@IsString()`, aligning it with the expected input type.
* Updated the import of `Status` in `aircraft.entity.ts` to a type-only import, improving type safety and clarity.
* Modified the `status` column in `Aircraft` entity to use a plain enum type in the column definition, removing the explicit enum reference.

**Entity Relationship Correction**

* Removed the unnecessary `nullable: true` option from the `@JoinColumn` decorator in the `Manufacturer` entity's `aircrafts` relationship.