### PR TITLE
refactor: aircraft and airline services, aircraft interface

### DIFF
--- a/frontend/src/interfaces/AircraftInterface.ts
+++ b/frontend/src/interfaces/AircraftInterface.ts
@@ -1,5 +1,7 @@
 // Developed by Mateo Pineda
 // Internal imports
+import type { AirlineInterface } from '@/interfaces/AirlineInterface';
+import type { ManufacturerInterface } from '@/interfaces/ManufacturerInterface';
 import type { Status } from '@/types/AircraftTypes';
 
 export interface AircraftInterface {
@@ -10,8 +12,8 @@ export interface AircraftInterface {
   status: Status;
   firstFlightDate: string;
   imageURL: string;
-  airlineId: string;
-  manufacturerId: string;
+  airline: AirlineInterface;
+  manufacturer: ManufacturerInterface;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/services/AircraftService.ts
+++ b/frontend/src/services/AircraftService.ts
@@ -1,55 +1,47 @@
 // Developed by Mateo Pineda, Santiago Idárraga
 // External imports
-import { v4 as uuidv4 } from 'uuid';
+import axios from 'axios';
 
 // Internal imports
 import type { CreateAircraftDTO } from '@/dtos/aircraftDTO/CreateAircraftDTO';
 import type { AircraftInterface } from '@/interfaces/AircraftInterface';
 import type { UpdateAircraftDTO } from '@/dtos/aircraftDTO/UpdateAircraftDTO';
-import { useAircraftStore } from '@/stores/AircraftStore';
 
 export class AircraftService {
-  static getAircrafts(): AircraftInterface[] {
-    return useAircraftStore().aircrafts;
+  private static readonly apiUrl = import.meta.env.VITE_API_BASE_URL;
+
+  static async getAircrafts(): Promise<AircraftInterface[]> {
+    console.log(AircraftService.apiUrl);
+    return await axios.get(`${AircraftService.apiUrl}aircrafts`)
+      .then((response) => response.data);
   }
 
-  static getAircraftById(id: string): AircraftInterface | undefined {
-    return useAircraftStore().aircrafts.find((aircraft) => aircraft.id === id);
+  static async getAircraftById(id: string): Promise<AircraftInterface | undefined> {
+    return await axios.get(`${AircraftService.apiUrl}aircrafts/${id}`)
+      .then((response) => response.data);
   }
 
-  static createAircraft(aircraft: CreateAircraftDTO): void {
-    const id = uuidv4();
-    const createdAt = new Date().toISOString();
-    const updatedAt = new Date().toISOString();
+  static async createAircraft(aircraft: CreateAircraftDTO): Promise<AircraftInterface> {
+    const createdAircraft = await axios.post(`${AircraftService.apiUrl}aircrafts`, aircraft)
+      .then((response) => response.data);
 
-    useAircraftStore().aircrafts.push({ id, ...aircraft, createdAt, updatedAt });
+    return createdAircraft;
   }
 
-  static updateAircraft(updatedAircraft: UpdateAircraftDTO): void {
-    const index = useAircraftStore().aircrafts.findIndex(
-      (aircraft) => aircraft.id === updatedAircraft.id,
-    );
+  static async updateAircraft(aircraft: UpdateAircraftDTO): Promise<AircraftInterface> {
+    const updatedAircraft = await axios.patch(`${AircraftService.apiUrl}aircrafts/${aircraft.id}`, aircraft)
+      .then((response) => response.data);
 
-    if (index === -1) {
-      throw new Error('Aircraft not found');
-    }
-
-    useAircraftStore().aircrafts[index] = {
-      ...updatedAircraft,
-      updatedAt: new Date().toISOString(),
-    };
+    return updatedAircraft;
   }
 
-  static deleteAircraft(id: string): void {
-    const index = useAircraftStore().aircrafts.findIndex((aircraft) => aircraft.id === id);
-    if (index === -1) {
-      throw new Error('Aircraft not found');
-    }
-
-    useAircraftStore().aircrafts.splice(index, 1);
+  static async deleteAircraft(id: string): Promise<void> {
+    await axios.delete(`${AircraftService.apiUrl}aircrafts/${id}`);
   }
 
-  static getAircraftsByAirlineId(airlineId: string): AircraftInterface[] {
-    return useAircraftStore().aircrafts.filter((aircraft) => aircraft.airlineId === airlineId);
+  static async getAircraftsByAirlineId(airlineId: string): Promise<AircraftInterface[]> {
+    const aircrafts = await AircraftService.getAircrafts();
+
+    return aircrafts.filter((aircraft) => aircraft.airline.id === airlineId);
   }
 }

--- a/frontend/src/services/AircraftService.ts
+++ b/frontend/src/services/AircraftService.ts
@@ -11,7 +11,6 @@ export class AircraftService {
   private static readonly apiUrl = import.meta.env.VITE_API_BASE_URL;
 
   static async getAircrafts(): Promise<AircraftInterface[]> {
-    console.log(AircraftService.apiUrl);
     return await axios.get(`${AircraftService.apiUrl}aircrafts`)
       .then((response) => response.data);
   }

--- a/frontend/src/services/AirlineService.ts
+++ b/frontend/src/services/AirlineService.ts
@@ -1,59 +1,51 @@
 // Developed by Mateo Pineda, Juan Jara, Santiago Idárraga
 // External imports
-import { v4 as uuidv4 } from 'uuid';
+import axios from 'axios';
 
 // Internal imports
 import type { AirlineInterface } from '@/interfaces/AirlineInterface';
 import { AircraftService } from './AircraftService';
 import type { CreateAirlineDTO } from '@/dtos/airlineDTO/CreateAirlineDTO';
 import type { UpdateAirlineDTO } from '@/dtos/airlineDTO/UpdateAirlineDTO';
-import { useAirlineStore } from '@/stores/AirlineStore';
 
 export class AirlineService {
-  static getAirlines(): AirlineInterface[] {
-    return useAirlineStore().airlines;
+  private static readonly apiUrl = import.meta.env.VITE_API_BASE_URL;
+
+  static async getAirlines(): Promise<AirlineInterface[]> {
+    const airlines = await axios.get(`${AirlineService.apiUrl}airlines`)
+      .then((response) => response.data);
+
+    return airlines;
   }
 
-  static getAirlineById(id: string): AirlineInterface | undefined {
-    return useAirlineStore().airlines.find((airline) => airline.id === id);
+  static async getAirlineById(id: string): Promise<AirlineInterface | undefined> {
+    const airline = await axios.get(`${AirlineService.apiUrl}airlines/${id}`)
+      .then((response) => response.data);
+
+    return airline;
   }
 
-  static createAirline(airline: CreateAirlineDTO): void {
-    const id = uuidv4();
-    const createdAt = new Date().toISOString();
-    const updatedAt = new Date().toISOString();
+  static async createAirline(airline: CreateAirlineDTO): Promise<AirlineInterface> {
+    const createdAirline = await axios.post(`${AirlineService.apiUrl}airlines`, airline)
+      .then((response) => response.data);
 
-    useAirlineStore().airlines.push({ id, ...airline, createdAt, updatedAt });
+    return createdAirline;
   }
 
-  static updateAirline(updatedAirline: UpdateAirlineDTO): void {
-    const index = useAirlineStore().airlines.findIndex(
-      (airline) => airline.id === updatedAirline.id,
-    );
+  static async updateAirline(airline: UpdateAirlineDTO): Promise<AirlineInterface> {
+    const updatedAirline = await axios.patch(`${AirlineService.apiUrl}airlines/${airline.id}`, airline)
+      .then((response) => response.data);
 
-    if (index === -1) {
-      throw new Error('Airline not found');
-    }
-
-    useAirlineStore().airlines[index] = {
-      ...updatedAirline,
-      updatedAt: new Date().toISOString(),
-    };
+    return updatedAirline;
   }
 
-  static deleteAirline(id: string): void {
-    const index = useAirlineStore().airlines.findIndex((airline) => airline.id === id);
-
-    if (index === -1) {
-      throw new Error('Airline not found');
-    }
-
-    useAirlineStore().airlines.splice(index, 1);
+  static async deleteAirline(id: string): Promise<void> {
+    await axios.delete(`${AirlineService.apiUrl}airlines/${id}`);
   }
 
   // Dashboard helpers
-  static getNumberOfDestinations(airlineId: string): number {
-    const airline = AirlineService.getAirlineById(airlineId);
+  static async getNumberOfDestinations(airlineId: string): Promise<number> {
+    const airline = await AirlineService.getAirlineById(airlineId);
 
     if (!airline) {
       return 0;
@@ -62,8 +54,8 @@ export class AirlineService {
     return airline.destinations.length;
   }
 
-  static getMostCommonAircraft(airlineId: string): string {
-    const aircrafts = AircraftService.getAircraftsByAirlineId(airlineId);
+  static async getMostCommonAircraft(airlineId: string): Promise<string> {
+    const aircrafts = await AircraftService.getAircraftsByAirlineId(airlineId);
 
     if (aircrafts.length === 0) {
       return 'N/A';


### PR DESCRIPTION
This pull request refactors the frontend data access layer for aircraft and airline entities, moving from a local store-based approach to using asynchronous HTTP requests via `axios`. It also updates the `AircraftInterface` to embed related objects instead of using just their IDs. These changes improve data consistency with the backend and set up the codebase for more robust API interaction.

**API Integration and Data Fetching:**

* Replaced all local store-based CRUD operations in `AircraftService` and `AirlineService` with asynchronous HTTP requests to the backend API using `axios`. This affects all methods for fetching, creating, updating, and deleting aircraft and airlines. [[1]](diffhunk://#diff-d3e66042bbb34f278df072e08d49ed646ec81da305d6efa3ad7ab2f7fba29e64L3-R45) [[2]](diffhunk://#diff-e31eda3a10d1b790ed4eb81785245f6edabe694abf01da38121ef00c01a3a10bL3-R48)

**Data Model Updates:**

* Updated `AircraftInterface` to reference `AirlineInterface` and `ManufacturerInterface` objects directly (as `airline` and `manufacturer`), instead of just their IDs. [[1]](diffhunk://#diff-fdd4ed2aef9e26dac983bfeaa9f35f97e68c6ca79550b3d660b63ac297b07bb7R3-R4) [[2]](diffhunk://#diff-fdd4ed2aef9e26dac983bfeaa9f35f97e68c6ca79550b3d660b63ac297b07bb7L13-R16)

**Dashboard Helper Methods:**

* Refactored dashboard helper methods in `AirlineService` (`getNumberOfDestinations`, `getMostCommonAircraft`) to be asynchronous and compatible with the new API-based data fetching. [[1]](diffhunk://#diff-e31eda3a10d1b790ed4eb81785245f6edabe694abf01da38121ef00c01a3a10bL3-R48) [[2]](diffhunk://#diff-e31eda3a10d1b790ed4eb81785245f6edabe694abf01da38121ef00c01a3a10bL65-R58)

These changes modernize the frontend's data layer, making it more scalable and better aligned with RESTful backend practices.