### PR TITLE
Feat/ssr section

### DIFF
--- a/nuxt/app/app.vue
+++ b/nuxt/app/app.vue
@@ -7,7 +7,7 @@
       <nav aria-label="Main">
         <ul class="nav mb-0">
           <li class="nav-item">
-            <NuxtLink class="nav-link py-1 px-2" to="/" active-class="active">Airlines</NuxtLink>
+            <NuxtLink class="nav-link py-1 px-2" to="/airlines" active-class="active">Airlines</NuxtLink>
           </li>
           <li class="nav-item">
             <NuxtLink class="nav-link py-1 px-2" to="/blog" active-class="active">Blog</NuxtLink>

--- a/nuxt/app/pages/airlines/[id].vue
+++ b/nuxt/app/pages/airlines/[id].vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+const { data: response } = await useFetch('/api/airlines')
+const airlinesData = response.value?.airlines
+
+const route = useRoute()
+const id = String(route.params.id)
+const airline = airlinesData?.find((airline) => airline.id === id)
+
+if (!airline) {
+    throw createError({ statusCode: 404, statusMessage: 'Airline not found', fatal: true })
+}
+</script>
+<template>
+    <header class="mb-8">
+        <div class="d-flex justify-content-between align-items-start">
+            <div>
+                <h2 class="text-3xl text-primary-900 font-black tracking-tight mb-2">Airlines Information</h2>
+                <p class="mb-0">Get to know {{ airline.name }}</p>
+            </div>
+            <div class="ms-3">
+                <a href="/airlines" class="btn btn-secondary">Back</a>
+            </div>
+        </div>
+    </header>
+    <div class="card mt-1 w-50 mx-auto">
+        <img class="card-img-top" :src="airline.imageURL" :alt="airline.name">
+        <div class="card-body">
+            <h5 class="card-title">{{ airline.name }}</h5>
+            <p class="card-text">{{ airline.country }}</p>
+        </div>
+        <ul class="list-group list-group-flush">
+            <li class="list-group-item">Destinations: {{ airline.destinations.join(', ') }}</li>
+            <li class="list-group-item">Aircrafts: {{ airline.aircrafts.join(', ') }}</li>
+        </ul>
+    </div>
+</template>

--- a/nuxt/app/pages/airlines/index.vue
+++ b/nuxt/app/pages/airlines/index.vue
@@ -21,6 +21,9 @@ const airlinesData = data?.value?.airlines;
                     <li class="list-group-item">Destinations: {{ airline.destinations?.join(', ') }}</li>
                     <li class="list-group-item">Aircrafts: {{ airline.aircrafts?.join(', ') }}</li>
                 </ul>
+                <div class="card-body">
+                    <a :href="`/airlines/${airline.id}`" class="btn btn-primary">+ More Information</a>
+                </div>
             </div>
         </div>
     </div>

--- a/nuxt/app/pages/airlines/index.vue
+++ b/nuxt/app/pages/airlines/index.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+const { data } = await useFetch('/api/airlines')
+
+const airlinesData = data?.value?.airlines;
+</script>
+
+<template>
+    <header class="mb-8">
+      <h2 class="text-3xl text-primary-900 font-black tracking-tight mb-2">Airlines Information</h2>
+      <p>Get to know some of the most well known airlines in the world</p>
+    </header>
+    <div class="row g-4">
+        <div v-for="airline in airlinesData" :key="airline.id" class="col-12 col-sm-6 col-lg-4 col-xl-3 d-flex">
+            <div class="card w-100">
+                <img class="card-img-top" :src="airline.imageURL" :alt="airline.name">
+                <div class="card-body">
+                    <h5 class="card-title">{{ airline.name }}</h5>
+                    <p class="card-text">{{ airline.country }}</p>
+                </div>
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">Destinations: {{ airline.destinations?.join(', ') }}</li>
+                    <li class="list-group-item">Aircrafts: {{ airline.aircrafts?.join(', ') }}</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</template> 

--- a/nuxt/app/pages/airlines/index.vue
+++ b/nuxt/app/pages/airlines/index.vue
@@ -6,8 +6,15 @@ const airlinesData = data?.value?.airlines;
 
 <template>
     <header class="mb-8">
-      <h2 class="text-3xl text-primary-900 font-black tracking-tight mb-2">Airlines Information</h2>
-      <p>Get to know some of the most well known airlines in the world</p>
+        <div class="d-flex justify-content-between align-items-start">
+            <div>
+                <h2 class="text-3xl text-primary-900 font-black tracking-tight mb-2">Airlines Information</h2>
+                <p>Get to know some of the most well known airlines in the world</p>
+            </div>
+            <div class="ms-3">
+                <a href="/" class="btn btn-secondary">Back</a>
+            </div>
+        </div>
     </header>
     <div class="row g-4">
         <div v-for="airline in airlinesData" :key="airline.id" class="col-12 col-sm-6 col-lg-4 col-xl-3 d-flex">
@@ -18,8 +25,7 @@ const airlinesData = data?.value?.airlines;
                     <p class="card-text">{{ airline.country }}</p>
                 </div>
                 <ul class="list-group list-group-flush">
-                    <li class="list-group-item">Destinations: {{ airline.destinations?.join(', ') }}</li>
-                    <li class="list-group-item">Aircrafts: {{ airline.aircrafts?.join(', ') }}</li>
+                    <li class="list-group-item">Destinations: {{ airline.destinations.join(', ') }}</li>
                 </ul>
                 <div class="card-body">
                     <a :href="`/airlines/${airline.id}`" class="btn btn-primary">+ More Information</a>

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -2,7 +2,10 @@
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
-    app: {
+  routeRules: {
+    'airlines/**': { ssr: true },
+  },
+  app: {
     head: {
       link: [
         {

--- a/nuxt/server/api/airlines.ts
+++ b/nuxt/server/api/airlines.ts
@@ -1,0 +1,63 @@
+export default defineEventHandler((event) => {
+    const airlines = {
+        airlines: [
+            {
+                id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                name: 'SkyControl Airlines',
+                country: 'US',
+                destinations: ['US', 'CA', 'MX', 'PA'],
+                imageURL:
+                'https://img.freepik.com/vector-gratis/avion-trayectoria-vuelo-circular_78370-4778.jpg',
+                aircrafts: ['N737AG', 'N738AG', 'N739AG'],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            },
+            {
+                id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+                name: 'Global Wings',
+                country: 'GB',
+                destinations: ['GB', 'FR', 'DE', 'ES', 'IT'],
+                imageURL:
+                'https://img.freepik.com/vector-gratis/avion-trayectoria-vuelo-circular_78370-4778.jpg',
+                aircrafts: ['G123GB', 'G456GB', 'G789GB'],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            },
+            {
+                id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+                name: 'AeroNova',
+                country: 'CA',
+                destinations: ['CA', 'US'],
+                imageURL:
+                'https://img.freepik.com/vector-gratis/avion-trayectoria-vuelo-circular_78370-4778.jpg',
+                aircrafts: ['A123CA', 'A456CA', 'A789CA'],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            },
+            {
+                id: 'cccccccc-cccc-4ccc-9ccc-cccccccccccc',
+                name: 'AeroCanada',
+                country: 'CA',
+                destinations: ['CA', 'US', 'CO', 'AR'],
+                imageURL:
+                'https://img.freepik.com/vector-gratis/avion-trayectoria-vuelo-circular_78370-4778.jpg',
+                aircrafts: ['C123CA', 'C456CA', 'C789CA'],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            },
+            {
+                id: 'cccccccc-cccc-4ccc-0ccc-cccccccccccc',
+                name: 'Americana Airlines',
+                country: 'US',
+                destinations: ['US', 'CU', 'DO'],
+                imageURL:
+                'https://img.freepik.com/vector-gratis/avion-trayectoria-vuelo-circular_78370-4778.jpg',
+                aircrafts: ['A123US', 'A456US', 'A789US'],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            }
+        ]
+    };
+
+    return airlines;
+});


### PR DESCRIPTION
This pull request adds a new Airlines feature to the Nuxt application, including both backend API and frontend pages for listing airlines and viewing detailed information about each airline. The main changes include creating an API endpoint to provide airline data, implementing pages to display this data, and updating navigation to reflect the new route structure.

**Airlines API and Data Handling:**

* Added a new API endpoint at `/api/airlines` that returns a hardcoded list of airlines, each with details such as name, country, destinations, aircrafts, and image URL.

**Frontend Pages for Airlines:**

* Created the `airlines/index.vue` page to display a list of all airlines, including their basic information and a link to a detail page for each airline.
* Added the `airlines/[id].vue` page to show detailed information about a specific airline, including error handling for unknown IDs. ([nuxt/app/pages/airlines/[id].vueR1-R36](diffhunk://#diff-e59de7d2c117a68cd05d445769a389a68a3250646a9f51c4ca617741fd20f222R1-R36))

**Navigation Updates:**

* Updated the main navigation link for "Airlines" to point to `/airlines` instead of the root path, ensuring correct routing to the new airlines list page.